### PR TITLE
Change Regional country mapping from None to REG

### DIFF
--- a/ckanext/spc/harvesters/nada_harvester.py
+++ b/ckanext/spc/harvesters/nada_harvester.py
@@ -36,7 +36,7 @@ country_mapping = {
    "VAN": "VU",
    "VUT": "VU",
    "WLF": "WF",
-   None: "Regional"
+   "REG": "Regional"
 }
 
 '''


### PR DESCRIPTION
Harvester's DDI-to-CKAN mapping did not yet include 'REG' for 'Regional'. Now it does.